### PR TITLE
Fix footer overlap on People page

### DIFF
--- a/media/html/public_contact.html
+++ b/media/html/public_contact.html
@@ -23,8 +23,6 @@
             <p>
               <span class="contactH2">Office</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="peopleH2">(650) 723-5976</span>
               <br/>
-              <span class="contactH2">Lab</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="peopleH2">(650) 723-7310</span>
-              <br/>
               <span class="contactH2">Admin</span>&nbsp;&nbsp;&nbsp;<span class="peopleH2">(650) 498-5118</span>
             </p>
             <p><span class="contactH2">E-mail</span>&nbsp;&nbsp;&nbsp;&nbsp;rhiju <i>[at]</i> stanford.edu</p>

--- a/media/js/public/main.js
+++ b/media/js/public/main.js
@@ -59,7 +59,7 @@ app.fnChangeView = function() {
   } else if (app.page == 'people') {
     var current_member = $("tr.current_member").length - 1,
         past_member = $("p.past_member").length,
-        height_adjust = current_member * 200 + past_member * 54;
+        height_adjust = current_member * 200 + past_member * 56;
     $(".DASpeople").css("height", height_adjust + 900);
 
   } else if (app.page == 'news') {


### PR DESCRIPTION
There is a function in `main.js` that handles changing views, and handles setting the body height for each page (because all the elements on the page are absolutely positioned). Eventually this should be replaced with modern layout techniques, but for now I've adjusted one of the magic numbers in the `people` view height handler to give more space.

Closes #7.